### PR TITLE
Catching any exception type from evaluate_derivatives in cvodes sim numerical error handling.

### DIFF
--- a/myokit/_sim/cvodessim.py
+++ b/myokit/_sim/cvodessim.py
@@ -809,7 +809,7 @@ class Simulation(myokit.CModule):
                 # not, add the error to the error message.
                 try:
                     self._model.evaluate_derivatives(state)
-                except myokit.NumericalError as en:
+                except Exception as en:
                     txt.append(str(en))
 
                 # Raise numerical simulation error


### PR DESCRIPTION
Closes #911