### PR TITLE
Only call basicConfig from within a 'if __name__ == main'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This page lists the main changes made to Myokit in each release.
   - [#918](https://github.com/myokit/myokit/pull/918) Fixed error when `var()` was called on a `PartialDerivative` with a `Derivative` as first argument.
   - [#933](https://github.com/myokit/myokit/pull/933) Made `myokit.step` base its error classification (large/small/none) on numerics, not representation.
   - [#947](https://github.com/myokit/myokit/pull/947) Fixed minor memory leak (reference counting issue) when using fixed form protocols.
+  - [#967](https://github.com/myokit/myokit/pull/967) Myokit no longer calls `logging.basicConfig()` when used as a library.
 
 ## [1.33.9] - 2022-11-08
 - Fixed

--- a/myokit/__init__.py
+++ b/myokit/__init__.py
@@ -32,14 +32,6 @@ from __future__ import print_function, unicode_literals
 
 
 #
-# Configure logging
-#
-import logging  # noqa  (not at top of file)
-logging.basicConfig()
-del logging
-
-
-#
 # Check python version
 #
 # Hexversion guide:

--- a/myokit/__main__.py
+++ b/myokit/__main__.py
@@ -2187,4 +2187,7 @@ def add_video_parser(subparsers):
 
 
 if __name__ == '__main__':
+    import logging
+    logging.basicConfig()
+
     main()

--- a/myokit/formats/axon/_abf.py
+++ b/myokit/formats/axon/_abf.py
@@ -254,7 +254,6 @@ class AbfFile(object):
             # cases that trigger this error they should be resolved. At the
             # same time, if it happens to a user we want it to "sort-of work"
             # (an experimental rather than a production setting)
-            logging.basicConfig()
             log = logging.getLogger(__name__)
             log.warning('Unable to read protocol from ' + self._filepath)
             log.warning(traceback.format_exc())
@@ -1065,7 +1064,6 @@ class AbfFile(object):
 
                     else:  # pragma: no cover
 
-                        logging.basicConfig()
                         log = logging.getLogger(__name__)
                         log.warning(
                             'Unsupported epoch type: ' + epoch_types(kind))


### PR DESCRIPTION
Part of #964 

`logging.basicConfig` should be called
- from within __name__ == '__main__'
- by scripts and applications

So not by myokit when used as a library, only when via __main__