### PR TITLE
Renamed 'myokit' component in imported SBML documents to 'global'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This page lists the main changes made to Myokit in each release.
   - [#953](https://github.com/myokit/myokit/pull/953) The DataLogViewer now overlaps traces with numbering (e.g. 0.membrane.V and 1.membrane.V), and toggles between files and variables with Page up and down Or Ctrl+Page up and down.
   - [#962](https://github.com/myokit/myokit/pull/962) Scipy is no longer a required dependency.
   - [#962](https://github.com/myokit/myokit/pull/962) The DataLogViewer only supports Matlab file loading if SciPy is installed.
+  - [#975](https://github.com/myokit/myokit/pull/975) Global parameters in imported SBML documents are now placed in a component named `global` instead of `myokit`.
 - Deprecated
   - [#918](https://github.com/myokit/myokit/pull/918) `Model.state` is deprecated in favour of `Model.initial_values`.
   - [#918](https://github.com/myokit/myokit/pull/918) `Model.set_state` is deprecated in favour of `Model.set_initial_values`.

--- a/myokit/formats/sbml/_api.py
+++ b/myokit/formats/sbml/_api.py
@@ -52,8 +52,8 @@ class Quantity(object):
         """
         if not isinstance(value, myokit.Expression):
             raise SBMLError(
-                '<' + str(value) + '> needs to be an instance of '
-                'myokit.Expression.')
+                '<' + str(value) + '> needs to be an instance of'
+                ' myokit.Expression.')
 
         self._initial_value = value
 
@@ -75,8 +75,8 @@ class Quantity(object):
         """
         if not isinstance(value, myokit.Expression):
             raise SBMLError(
-                '<' + str(value) + '> needs to be an instance of '
-                'myokit.Expression.')
+                '<' + str(value) + '> needs to be an instance of'
+                ' myokit.Expression.')
 
         self._value = value
         self._is_rate = bool(is_rate)
@@ -126,8 +126,8 @@ class Compartment(Quantity):
 
         if not isinstance(model, Model):
             raise SBMLError(
-                '<' + str(model) + '> needs to be an instance of '
-                'myokit.formats.sbml.Model.')
+                '<' + str(model) + '> needs to be an instance of'
+                ' myokit.formats.sbml.Model.')
 
         self._model = model
         self._sid = str(sid)
@@ -280,7 +280,7 @@ class Model(object):
         if not isinstance(compartment, Compartment):
             raise SBMLError(
                 '<' + compartment + '> needs to be instance of'
-                'myokit.formats.sbml.Compartment')
+                ' myokit.formats.sbml.Compartment')
 
         sid = str(sid) if sid else sid
         self._register_sid(sid)
@@ -427,7 +427,7 @@ class Model(object):
         if not isinstance(factor, Parameter):
             raise SBMLError(
                 '<' + str(factor) + '> needs to be instance of'
-                'myokit.formats.sbml.Parameter.')
+                ' myokit.formats.sbml.Parameter.')
 
         self._conversion_factor = factor
 
@@ -585,8 +585,8 @@ class Parameter(Quantity):
 
         if not isinstance(model, Model):
             raise SBMLError(
-                '<' + str(model) + '> needs to be an instance of '
-                'myokit.formats.sbml.Model.')
+                '<' + str(model) + '> needs to be an instance of'
+                ' myokit.formats.sbml.Model.')
 
         self._model = model
         self._sid = str(sid)
@@ -629,8 +629,8 @@ class Reaction(object):
 
         if not isinstance(model, Model):
             raise SBMLError(
-                '<' + str(model) + '> needs to be an instance of '
-                'myokit.formats.sbml.Model.')
+                '<' + str(model) + '> needs to be an instance of'
+                ' myokit.formats.sbml.Model.')
 
         self._model = model
         self._sid = str(sid)
@@ -650,8 +650,8 @@ class Reaction(object):
         """Adds a modifier to this reaction and returns the created object."""
         if not isinstance(species, Species):
             raise SBMLError(
-                '<' + str(species) + '> needs to be an instance of '
-                'myokit.formats.sbml.Species')
+                '<' + str(species) + '> needs to be an instance of'
+                ' myokit.formats.sbml.Species')
 
         sid = str(sid) if sid else sid
         if sid is not None:
@@ -668,8 +668,8 @@ class Reaction(object):
         """
         if not isinstance(species, Species):
             raise SBMLError(
-                '<' + str(species) + '> needs to be an instance of '
-                'myokit.formats.sbml.Species')
+                '<' + str(species) + '> needs to be an instance of'
+                ' myokit.formats.sbml.Species')
 
         sid = str(sid) if sid else sid
         if sid is not None:
@@ -685,8 +685,8 @@ class Reaction(object):
         """Adds a reactant to this reaction and returns the created object."""
         if not isinstance(species, Species):
             raise SBMLError(
-                '<' + str(species) + '> needs to be an instance of '
-                'myokit.formats.sbml.Species')
+                '<' + str(species) + '> needs to be an instance of'
+                ' myokit.formats.sbml.Species')
 
         sid = str(sid) if sid else sid
         if sid is not None:
@@ -731,8 +731,8 @@ class Reaction(object):
         """
         if not isinstance(expression, myokit.Expression):
             raise SBMLError(
-                '<' + str(expression) + '> needs to be an instance of '
-                'myokit.Expression.')
+                '<' + str(expression) + '> needs to be an instance of'
+                ' myokit.Expression.')
 
         self._kinetic_law = expression
 
@@ -777,7 +777,7 @@ class Species(Quantity):
         if not isinstance(compartment, Compartment):
             raise SBMLError(
                 '<' + compartment + '> needs to be instance of'
-                'myokit.formats.sbml.Compartment')
+                ' myokit.formats.sbml.Compartment')
         if not isinstance(is_amount, bool):
             raise SBMLError(
                 'Is_amount <' + str(is_amount) + '> needs to be a boolean.')
@@ -853,7 +853,7 @@ class Species(Quantity):
         if not isinstance(factor, Parameter):
             raise SBMLError(
                 '<' + str(factor) + '> needs to be instance of'
-                'myokit.formats.sbml.Parameter.')
+                ' myokit.formats.sbml.Parameter.')
 
         self._conversion_factor = factor
 
@@ -867,8 +867,8 @@ class Species(Quantity):
         """
         if not isinstance(value, myokit.Expression):
             raise SBMLError(
-                '<' + str(value) + '> needs to be an instance of '
-                'myokit.Expression.')
+                '<' + str(value) + '> needs to be an instance of'
+                ' myokit.Expression.')
         if (in_amount is not None) and (not isinstance(in_amount, bool)):
             raise SBMLError(
                 '<in_amount> needs to be an instance of bool or None.')
@@ -919,7 +919,7 @@ class SpeciesReference(Quantity):
         if not isinstance(species, Species):
             raise SBMLError(
                 '<' + species + '> needs to be instance of'
-                'myokit.formats.sbml.Species')
+                ' myokit.formats.sbml.Species')
 
         self._species = species
         self._sid = str(sid) if sid else sid
@@ -945,7 +945,7 @@ class ModifierSpeciesReference(object):
         if not isinstance(species, Species):
             raise SBMLError(
                 '<' + species + '> needs to be instance of'
-                'myokit.formats.sbml.Species')
+                ' myokit.formats.sbml.Species')
 
         self._species = species
         self._sid = str(sid) if sid else sid
@@ -1058,7 +1058,7 @@ class _MyokitConverter(object):
 
     @staticmethod
     def add_global_component(
-            myokit_model, component_references, name='myokit'):
+            myokit_model, component_references, name='global'):
         """
         Creates a component used to store global parameters and the time
         variable.

--- a/myokit/tests/test_sbml_api.py
+++ b/myokit/tests/test_sbml_api.py
@@ -1214,7 +1214,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         c.set_initial_value(myokit.Name(p))
         mm = sm.myokit_model()
         self.assertTrue(mm.has_component('comp'))
-        self.assertEqual(mm.get('comp.size').rhs().code(), 'myokit.parameter')
+        self.assertEqual(mm.get('comp.size').rhs().code(), 'global.parameter')
         self.assertFalse(mm.get('comp.size').is_state())
 
         # Check setting size as value
@@ -1241,7 +1241,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         c.set_value(myokit.Name(p))
         mm = sm.myokit_model()
         self.assertTrue(mm.has_component('comp'))
-        self.assertEqual(mm.get('comp.size').rhs().code(), 'myokit.parameter')
+        self.assertEqual(mm.get('comp.size').rhs().code(), 'global.parameter')
         self.assertFalse(mm.get('comp.size').is_state())
 
         # Check setting size as rate
@@ -1289,9 +1289,9 @@ class SBMLTestMyokitModel(unittest.TestCase):
         m = m.myokit_model()
 
         # Check that model created parameters in 'global' component
-        self.assertTrue(m.has_variable('myokit.z'))
-        self.assertTrue(m.has_variable('myokit.boat'))
-        self.assertTrue(m.has_variable('myokit.c'))
+        self.assertTrue(m.has_variable('global.z'))
+        self.assertTrue(m.has_variable('global.boat'))
+        self.assertTrue(m.has_variable('global.c'))
 
         # Check that total number of parameters is 4 (3 parameters and time)
         self.assertEqual(m.count_variables(), 4)
@@ -1303,7 +1303,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         p = m.add_parameter('param')
         p.set_initial_value(myokit.Number(7))
         mm = m.myokit_model()
-        pp = mm.get('myokit.param')
+        pp = mm.get('global.param')
         self.assertFalse(pp.is_state())
         self.assertEqual(pp.rhs(), myokit.Number(7))
 
@@ -1311,7 +1311,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         self.assertIsNone(pp.unit())
         p.set_units(myokit.units.pF)
         mm = m.myokit_model()
-        pp = mm.get('myokit.param')
+        pp = mm.get('global.param')
         self.assertFalse(pp.is_state())
         self.assertEqual(pp.rhs(), myokit.Number(7))
         self.assertEqual(pp.unit(), myokit.units.pF)
@@ -1331,7 +1331,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         p = m.add_parameter('param')
         p.set_value(myokit.Plus(myokit.Number(7), myokit.Number(3)))
         mm = m.myokit_model()
-        pp = mm.get('myokit.param')
+        pp = mm.get('global.param')
         self.assertFalse(pp.is_state())
         self.assertEqual(
             pp.rhs(), myokit.Plus(myokit.Number(7), myokit.Number(3)))
@@ -1340,7 +1340,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         self.assertIsNone(pp.unit())
         p.set_units(myokit.units.pF)
         mm = m.myokit_model()
-        pp = mm.get('myokit.param')
+        pp = mm.get('global.param')
         self.assertFalse(pp.is_state())
         self.assertEqual(pp.rhs().code(), '7 + 3')
         self.assertEqual(pp.unit(), myokit.units.pF)
@@ -1361,7 +1361,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         p.set_value(myokit.Number(3.2), is_rate=True)
         with WarningCollector():
             mm = m.myokit_model()
-        pp = mm.get('myokit.param')
+        pp = mm.get('global.param')
         self.assertTrue(pp.is_state())
         self.assertEqual(pp.rhs(), myokit.Number(3.2))
         self.assertEqual(pp.initial_value(as_float=True), 0)
@@ -1369,7 +1369,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         # With initial value
         p.set_initial_value(myokit.Number(1))
         mm = m.myokit_model()
-        pp = mm.get('myokit.param')
+        pp = mm.get('global.param')
         self.assertTrue(pp.is_state())
         self.assertEqual(pp.rhs(), myokit.Number(3.2))
         self.assertEqual(pp.initial_value(as_float=True), 1)
@@ -1378,7 +1378,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         self.assertIsNone(pp.unit())
         p.set_units(myokit.units.pF)
         mm = m.myokit_model()
-        pp = mm.get('myokit.param')
+        pp = mm.get('global.param')
         self.assertTrue(pp.is_state())
         self.assertEqual(pp.rhs(), myokit.Number(3.2))
         self.assertEqual(pp.unit(), myokit.units.pF)
@@ -1478,7 +1478,7 @@ class SBMLTestMyokitModel(unittest.TestCase):
         mm = m.myokit_model()
         ms = mm.get('comp.spec_1_amount')
         self.assertFalse(ms.is_state())
-        self.assertEqual(ms.rhs().code(), 'myokit.p1')
+        self.assertEqual(ms.rhs().code(), 'global.p1')
 
         # Species in concentration: unreferenced parameter
         p2 = sbml.Parameter(m, 'p2')
@@ -2168,10 +2168,10 @@ class SBMLTestMyokitModel(unittest.TestCase):
         m = m.myokit_model()
 
         # Check that time variable exists
-        self.assertTrue(m.has_variable('myokit.time'))
+        self.assertTrue(m.has_variable('global.time'))
 
         # Check that unit is set
-        var = m.get('myokit.time')
+        var = m.get('global.time')
         self.assertEqual(var.unit(), myokit.units.ampere)
 
         # Check that initial value is set
@@ -2189,10 +2189,10 @@ class SBMLTestMyokitModel(unittest.TestCase):
         p = s.add_parameter('param')
         p.set_value(myokit.Plus(myokit.Number(1), myokit.Name(s.time())))
         m = s.myokit_model()
-        t = m.get('myokit.time')
+        t = m.get('global.time')
         self.assertEqual(t.unit(), myokit.units.ms)
         self.assertEqual(
-            m.get('myokit.param').rhs(),
+            m.get('global.param').rhs(),
             myokit.Plus(myokit.Number(1), myokit.Name(m.time())))
 
 

--- a/myokit/tests/test_sbml_parser.py
+++ b/myokit/tests/test_sbml_parser.py
@@ -913,12 +913,12 @@ class TestSBMLParser(unittest.TestCase):
         # Check species reactions (no unecessary zeros and all terms present)
         model_mmt = m.myokit_model().code()
         S1_rhs = \
-            'dot(S1_amount) = -(r1 * (size * myokit.k1 * S1_concentration)) ' \
-            + '- size * myokit.k1 * S1_concentration'
+            'dot(S1_amount) = -(r1 * (size * global.k1 * S1_concentration)) ' \
+            + '- size * global.k1 * S1_concentration'
         self.assertTrue(S1_rhs in model_mmt)
-        S2_rhs = 'dot(S2_amount) = r2 * (size * myokit.k1 * S1_concentration)'
+        S2_rhs = 'dot(S2_amount) = r2 * (size * global.k1 * S1_concentration)'
         self.assertTrue(S2_rhs in model_mmt)
-        S3_rhs = 'dot(S3_amount) = size * myokit.k1 * S1_concentration'
+        S3_rhs = 'dot(S3_amount) = size * global.k1 * S1_concentration'
         self.assertTrue(S3_rhs in model_mmt)
 
     def test_parse_rule(self):


### PR DESCRIPTION
Closes #793.