### PR TITLE
`myokit.save()` now raises a `ValueError` if `model`, `protocol`, and `script` are all None.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This page lists the main changes made to Myokit in each release.
   - [#933](https://github.com/myokit/myokit/pull/933) Made `myokit.step` base its error classification (large/small/none) on numerics, not representation.
   - [#947](https://github.com/myokit/myokit/pull/947) Fixed minor memory leak (reference counting issue) when using fixed form protocols.
   - [#967](https://github.com/myokit/myokit/pull/967) Myokit no longer calls `logging.basicConfig()` when used as a library.
+  - [#977](https://github.com/myokit/myokit/pull/977) `myokit.save()` now raises a `ValueError` if `model`, `protocol`, and `script` are all None.
 
 ## [1.33.9] - 2022-11-08
 - Fixed

--- a/myokit/_io.py
+++ b/myokit/_io.py
@@ -176,6 +176,10 @@ def save(filename=None, model=None, protocol=None, script=None):
 
     If no filename is given the ``mmt`` code is returned as a string.
     """
+    if model is None and protocol is None and script is None:
+        raise ValueError(
+            'At least one of [model, protocol, script] must not be None.')
+
     if filename:
         filename = os.path.expanduser(filename)
         f = open(filename, 'w')

--- a/myokit/tests/test_io.py
+++ b/myokit/tests/test_io.py
@@ -255,6 +255,12 @@ class LoadSaveMmtTest(unittest.TestCase):
                 text = f.read()
             self.assertEqual(text, myokit.save(model=m, protocol=p, script=x))
 
+        # Save nothing
+        with TemporaryDirectory() as d:
+            opath = d.path('test.mmt')
+            self.assertRaises(ValueError, myokit.save, opath)
+            self.assertFalse(os.path.exists(opath))
+
     def test_save_model(self):
         # Test if the correct parts are saved/loaded from disk using the
         # ``save_model()`` method.


### PR DESCRIPTION
Closes #639.