### PR TITLE
Adding readthedocs.yaml configuration file

### DIFF
--- a/.readthedocs.txt
+++ b/.readthedocs.txt
@@ -1,7 +1,0 @@
-matplotlib>=1.5
-numpy>=1.8
-scipy>=0.14
-sympy
-sip
-pyqt5
-docutils<0.18

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,40 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"  # Currently (2023-07-25) seems to be the sweet spot...
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    #- requirements: .requirements-docs.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - optional
+        - gui

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,7 +296,7 @@ Then have a look at `<your myokit path>/doc/build/html/index.html`.
 - Coverage is tested using [codecov.io](https://docs.codecov.io/docs) which builds on [coverage](https://coverage.readthedocs.io/). 
   Configuration file: `.coveragerc` ([syntax](https://coverage.readthedocs.io/en/latest/config.html)).
 - Documentation is built using [readthedocs](readthedocs.org) and [published here](https://myokit.readthedocs.io/).
-  Configuration file `.readthedocs.txt`.
+  Configuration file `.readthedocs.yaml`.
 - Code style is checked using flake8.
   Configuration file: `.flake8` ([syntax](http://flake8.pycqa.org/en/latest/user/configuration.html)).
 


### PR DESCRIPTION
- Will be required starting September 23
- Offers finer grained control than web interface

https://blog.readthedocs.com/migrate-configuration-v2/