### PR TITLE
Heka offset and datalog meta read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This page lists the main changes made to Myokit in each release.
   - [#1006](https://github.com/myokit/myokit/pull/1006) ABF, WCP, and PatchMaster file classes now add meta data when creating a `DataLog`.
 - Changed
   - [#1006](https://github.com/myokit/myokit/pull/1006) Made core classes `ObjectWithMetaData`, `MetaDataContainer`, `VarOwner`, and `VarProvider` part of the public API. Similarly the method `check_name`.
+  - [#1008](https://github.com/myokit/myokit/pull/1008) The `PatchMasterFile` reader no longer performs "zero offset subtraction" (in which a recorded current trace is shifted until a user-specified segment has zero current) by default.
 - Deprecated
 - Removed
 - Fixed


### PR DESCRIPTION
- Made DataLog read meta data when using save/load, which are supposed to be "proper" saving/loading of all parts of a log
- Did not do same for save_csv and load_csv, which are export/import type options
- PatchMasterFile no longer performs "zero offset subtraction" on recorded currents by default. This is nothing to do with "zeroing the current" before making the seal, but is an analysis option to make the current in a chosen stimulus segment be zero.