### PR TITLE
Made some changes to new C code to make it more C89-ish

### DIFF
--- a/myokit/_sim/__init__.py
+++ b/myokit/_sim/__init__.py
@@ -157,6 +157,7 @@ class CModule:
                         '-Wdeclaration-after-statement',
                         '-Wconversion',
                         '-Wno-unused-parameter',
+                        #'-std=c89',
                     ])
 
             # Add runtime_library_dirs to prevent LD_LIBRARY_PATH errors on

--- a/myokit/_sim/cmodel.h
+++ b/myokit/_sim/cmodel.h
@@ -464,6 +464,7 @@ Model_ClearCache(Model model)
 Model_Flag
 Model_SetupPacing(Model model, int n_pace)
 {
+    int i;
     if (model == NULL) return Model_INVALID_MODEL;
     if (n_pace < 0) return Model_INVALID_PACING;
 
@@ -480,7 +481,7 @@ Model_SetupPacing(Model model, int n_pace)
     }
 
     /* Clear values */
-    for (int i = 0; i < n_pace; i++) {
+    for (i = 0; i < n_pace; i++) {
         model->pace_values[i] = 0;
         /* Note: This will be overruled by the first call to SetBoundVariables */
     }
@@ -706,6 +707,7 @@ Model_SetBoundVariables(
     const realtype realtime,
     const realtype evaluations)
 {
+    int i;
     #ifdef Model_CACHING
     int changed;
     #endif
@@ -721,7 +723,7 @@ Model_SetBoundVariables(
         #endif
     }
 
-    for (int i = 0; i < model->n_pace; i++) {
+    for (i=0; i<model->n_pace; i++) {
         if (pace_values[i] != model->pace_values[i]) {
             model->pace_values[i] = pace_values[i];
             #ifdef Model_CACHING


### PR DESCRIPTION
After Chon reported this on a server:

```
Traceback (most recent call last):
  File "/home/chonloklei/testing-myokit/run.py", line 9, in <module>
    sim = myokit.Simulation(model)
  File "/home/chonloklei/voltage-clamp-decipher/env/lib/python3.9/site-packages/myokit/_sim/cvodessim.py", line 204, in __init__
    self._create_simulation(cmodel.code, path)
  File "/home/chonloklei/voltage-clamp-decipher/env/lib/python3.9/site-packages/myokit/_sim/cvodessim.py", line 272, in _create_simulation
    res = self._compile(
  File "/home/chonloklei/voltage-clamp-decipher/env/lib/python3.9/site-packages/myokit/_sim/__init__.py", line 231, in _compile
    raise myokit.CompilationError('\n'.join(t))
myokit._err.CompilationError: Unable to compile.
Error message:
error: command '/usr/bin/gcc' failed with exit code 1
Traceback (most recent call last):
  File "/home/chonloklei/voltage-clamp-decipher/env/lib/python3.9/site-packages/setuptools/_distutils/unixccompiler.py", line 185, in _compile
    self.spawn(compiler_so + cc_args + [src, '-o', obj] + extra_postargs)
  File "/home/chonloklei/voltage-clamp-decipher/env/lib/python3.9/site-packages/setuptools/_distutils/ccompiler.py", line 1041, in spawn
    spawn(cmd, dry_run=self.dry_run, **kwargs)
  File "/home/chonloklei/voltage-clamp-decipher/env/lib/python3.9/site-packages/setuptools/_distutils/spawn.py", line 70, in spawn
    raise DistutilsExecError(
distutils.errors.DistutilsExecError: command '/usr/bin/gcc' failed with exit code 1

... [some more similar error messages]

Compiler output:
    running build_ext
    building 'myokit_sim_1_670751483089940324' extension
    creating build
    creating build/temp.linux-x86_64-cpython-39
    creating build/temp.linux-x86_64-cpython-39/tmp
    creating build/temp.linux-x86_64-cpython-39/tmp/tmpvidx1ae3myokit
    gcc -pthread -B /home/chonloklei/voltage-clamp-decipher/env/compiler_compat -Wno-unused-result -Wsign-compare -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /home/chonloklei/voltage-clamp-decipher/env/include -I/home/chonloklei/voltage-clamp-decipher/env/include -fPIC -O2 -isystem /home/chonloklei/voltage-clamp-decipher/env/include -fPIC -I/usr/local/include -I/opt/local/include -I/home/chonloklei/sundials/include -I/home/chonloklei/voltage-clamp-decipher/env/lib/python3.9/site-packages/myokit/_sim -I/home/chonloklei/voltage-clamp-decipher/env/lib/python3.9/site-packages/myokit/_sim -I/home/chonloklei/voltage-clamp-decipher/env/include/python3.9 -c /tmp/tmpvidx1ae3myokit/source.c -o build/temp.linux-x86_64-cpython-39/tmp/tmpvidx1ae3myokit/source.o
    /tmp/tmpvidx1ae3myokit/source.c: In function 'Model_SetupPacing':
    /tmp/tmpvidx1ae3myokit/source.c:479:5: error: 'for' loop initial declarations are only allowed in C99 mode
         for (int i = 0; i < n_pace; i++) {
         ^
    /tmp/tmpvidx1ae3myokit/source.c:479:5: note: use option -std=c99 or -std=gnu99 to compile your code
    /tmp/tmpvidx1ae3myokit/source.c: In function 'Model_SetBoundVariables':
    /tmp/tmpvidx1ae3myokit/source.c:715:5: error: 'for' loop initial declarations are only allowed in C99 mode
         for (int i = 0; i < model->n_pace; i++) {
         ^
    /tmp/tmpvidx1ae3myokit/source.c: In function 'rhs':
    /tmp/tmpvidx1ae3myokit/source.c:1625:14: error: redeclaration of 'i' with no linkage
         for (int i = 0; i < n_pace; i++) {
                  ^
    /tmp/tmpvidx1ae3myokit/source.c:1622:9: note: previous declaration of 'i' was here
         int i;
             ^
    /tmp/tmpvidx1ae3myokit/source.c:1625:5: error: 'for' loop initial declarations are only allowed in C99 mode
         for (int i = 0; i < n_pace; i++) {
         ^
    /tmp/tmpvidx1ae3myokit/source.c: In function 'sim_clean':
    /tmp/tmpvidx1ae3myokit/source.c:1739:9: error: 'for' loop initial declarations are only allowed in C99 mode
             for (int i = 0; i < n_pace; i++) {
             ^
    /tmp/tmpvidx1ae3myokit/source.c: In function 'sim_init':
    /tmp/tmpvidx1ae3myokit/source.c:2252:9: error: 'for' loop initial declarations are only allowed in C99 mode
             for (int i = 0; i < PyList_Size(protocols); i++) {
             ^
    /tmp/tmpvidx1ae3myokit/source.c: In function 'sim_step':
    /tmp/tmpvidx1ae3myokit/source.c:2607:17: error: 'for' loop initial declarations are only allowed in C99 mode
                     for (int i = 0; i < n_pace; i++) {
                     ^
    /tmp/tmpvidx1ae3myokit/source.c:2789:13: error: 'for' loop initial declarations are only allowed in C99 mode
                 for (int i = 0; i < n_pace; i++) {
                 ^
    /tmp/tmpvidx1ae3myokit/source.c:2909:14: error: redeclaration of 'i' with no linkage
         for (int i = 0; i < n_pace; i++) {
                  ^
    /tmp/tmpvidx1ae3myokit/source.c:2554:9: note: previous declaration of 'i' was here
         int i, j;
             ^
    /tmp/tmpvidx1ae3myokit/source.c:2909:5: error: 'for' loop initial declarations are only allowed in C99 mode
         for (int i = 0; i < n_pace; i++) {
         ^
    /tmp/tmpvidx1ae3myokit/source.c: In function 'sim_eval_derivatives':
    /tmp/tmpvidx1ae3myokit/source.c:3003:14: error: redeclaration of 'i' with no linkage
         for (int i = 0; i < n_pace; i++) {
                  ^
    /tmp/tmpvidx1ae3myokit/source.c:2928:9: note: previous declaration of 'i' was here
         int i;
             ^
    /tmp/tmpvidx1ae3myokit/source.c:3003:5: error: 'for' loop initial declarations are only allowed in C99 mode
         for (int i = 0; i < n_pace; i++) {
```


