### PR TITLE
Patchmaster updates to read more amplifier properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This page lists the main changes made to Myokit in each release.
 ## Unreleased
 - Added
   - [#1010](https://github.com/myokit/myokit/pull/1010) Added more information methods to `formats.heka.Segment`
-  - [#1012](https://github.com/myokit/myokit/pull/1012) The method `add_variable` now has keyword arguments `unit`, `rhs`, `label`, `binding`, and `initial_value` to allow one-line variable creation and initialisation.
+  - [#1012](https://github.com/myokit/myokit/pull/1012) The method `Model.add_variable` now has keyword arguments `unit`, `rhs`, `label`, `binding`, and `initial_value` to allow one-line variable creation and initialisation.
+  - [#1018](https://github.com/myokit/myokit/pull/1018) The PatchMaster file reading can now extract information for multiple amplifiers (if used), and more information methods were added.
 - Changed
 - Deprecated
 - Removed

--- a/docs/source/api_formats/heka.rst
+++ b/docs/source/api_formats/heka.rst
@@ -74,6 +74,21 @@ stimuli, channels, and segments.
 
 .. autoclass:: NoSupportedDAChannelError
 
+"Amplifier file" classes
+------------------------
+
+An "amplifier file" provides access to amplifier information in situations
+where more than one amplifier was used.
+
+.. autoclass:: AmplifierFile
+
+.. autoclass:: AmplifierSeries
+
+.. autoclass:: AmplifierState
+
+.. autoclass:: AmplifierStateRecord
+
+
 Internals
 =========
 

--- a/docs/source/api_index/myokit.formats.rst
+++ b/docs/source/api_index/myokit.formats.rst
@@ -122,7 +122,11 @@ myokit.formats.easyml
 
 myokit.formats.heka
 ---------------------
+- :class:`myokit.formats.heka.AmplifierFile`
 - :class:`myokit.formats.heka.AmplifierMode`
+- :class:`myokit.formats.heka.AmplifierSeries`
+- :class:`myokit.formats.heka.AmplifierState`
+- :class:`myokit.formats.heka.AmplifierStateRecord`
 - :class:`myokit.formats.heka.EndianAwareReader`
 - :class:`myokit.formats.heka.Group`
 - :meth:`myokit.formats.heka.importers`

--- a/myokit/formats/heka/__init__.py
+++ b/myokit/formats/heka/__init__.py
@@ -4,7 +4,11 @@
 # This file is part of Myokit.
 # See http://myokit.org for copyright, sharing, and licensing details.
 from ._patchmaster import ( # noqa
+    AmplifierFile,
     AmplifierMode,
+    AmplifierSeries,
+    AmplifierState,
+    AmplifierStateRecord,
     EndianAwareReader,
     Group,
     NoSupportedDAChannelError,

--- a/myokit/formats/heka/_patchmaster.py
+++ b/myokit/formats/heka/_patchmaster.py
@@ -1682,7 +1682,7 @@ class AmplifierState:
     def c_slow_auto_settings(self):
         """
         Returns a tuple with the settings used when automatically estimating
-        C-slow: (Pulse amplitude in mV, number of cycles, Timeouet in s).
+        C-slow: (Pulse amplitude in mV, number of cycles, Timeout in s).
 
         See :meth:`c_slow`.
         """

--- a/myokit/formats/heka/_patchmaster.py
+++ b/myokit/formats/heka/_patchmaster.py
@@ -1016,7 +1016,7 @@ class Series(TreeNode, myokit.formats.SweepSource):
         # Resistance, capacitance, etc.
         a = self.amplifier_state()
         out.append('Information from amplifier state:')
-        out.append('  Current gain: {a.current_gain()} mV/pA')
+        out.append(f'  Current gain: {a.current_gain()} mV/pA')
         if a.ljp():
             out.append('  LJP correction applied using'
                        f' LJP={round(a.ljp(), 4)} mV.')

--- a/myokit/formats/heka/_patchmaster.py
+++ b/myokit/formats/heka/_patchmaster.py
@@ -1584,6 +1584,8 @@ class AmplifierState:
 
         handle.seek(i + 80)    # sCSlow = 80; (* LONGREAL *)
         self._cs = reader.read1('d')
+        handle.seek(i + 152)    # sCSlowStimVolts = 152; (* LONGREAL *)
+        self._cs_stim = reader.read1('d')
 
         handle.seek(i + 136)  # sVLiquidJunction = 136; (* LONGREAL *)
         self._ljp = reader.read1('d')
@@ -1651,6 +1653,12 @@ class AmplifierState:
         Returns the capacitance (cF) used in slow capacitance correction.
         """
         return self._cs * 1e12
+
+    def c_slow_stim_voltage(self):
+        """
+        Returns the test voltage (mV) used in estimating slow capacitance.
+        """
+        return self._cs_stim * 1e3
 
     def current_gain(self):
         """

--- a/myokit/formats/heka/_patchmaster.py
+++ b/myokit/formats/heka/_patchmaster.py
@@ -2767,6 +2767,10 @@ class AmplifierFile(TreeNode):
         self._version = reader.str(32)
         self._name = reader.str(32)
 
+    def name(self):
+        """ Returns an amplifier name. """
+        return self._name
+
     def version(self):
         """ Returns a string representation of this file's format version. """
         return self._version

--- a/myokit/formats/heka/_patchmaster.py
+++ b/myokit/formats/heka/_patchmaster.py
@@ -1587,6 +1587,8 @@ class AmplifierState:
         handle.seek(i + 152)    # sCSlowStimVolts = 152; (* LONGREAL *)
         self._cs_stim = reader.read1('d')
 
+        handle.seek(i + 128)  # sVpOffset = 128; (* LONGREAL *)
+        self._voff = reader.read1('d')
         handle.seek(i + 136)  # sVLiquidJunction = 136; (* LONGREAL *)
         self._ljp = reader.read1('d')
 
@@ -1702,6 +1704,12 @@ class AmplifierState:
         acquiring the trace.
         """
         return 1e-6 / self._g_series
+
+    def v_off(self):
+        """
+        Returns the Vp offset (in mV) used.
+        """
+        return self._voff * 1e3
 
 
 #

--- a/myokit/formats/heka/_patchmaster.py
+++ b/myokit/formats/heka/_patchmaster.py
@@ -1630,6 +1630,11 @@ class AmplifierState:
         handle.seek(i + 392)  # sVmonFiltFrequency = 392; (* LONGREAL *)
         self._temp['sVmonFiltFrequency'] = reader.read1('d')
 
+        handle.seek(i + 112)  # sVHold = 112; (* LONGREAL *)
+        self._temp['sVHold'] = reader.read1('d')
+        handle.seek(i + 120)  # sLastVHold = 120; (* LONGREAL *)
+        self._temp['sLastVHold'] = reader.read1('d')
+
     def c_fast(self):
         """
         Return the capacitance (pF) used in fast capacitance correction

--- a/myokit/formats/heka/_patchmaster.py
+++ b/myokit/formats/heka/_patchmaster.py
@@ -1595,6 +1595,11 @@ class AmplifierState:
         #TODO: Add these are proper properties with a docstring'd method that
         # returns them and says what the units are etc. or stop reading them.
         self._temp = {}
+        handle.seek(i + 304)  # sRsTau = 304; (* LONGREAL *)
+        self._temp['sRsTau'] = reader.read1('d')
+
+        handle.seek(i + 264)  # sImon1Bandwidth = 264; (* LONGREAL *)
+        self._temp['sImon1Bandwidth'] = reader.read1('d')
         handle.seek(i + 281)  # sFilter1 = 281; (* BYTE *)
         self._temp['sFilter1'] = reader.read1('b')
         handle.seek(i + 294)  # sF1Mode = 294; (* BYTE *)
@@ -1624,11 +1629,6 @@ class AmplifierState:
         self._temp['sVmonFiltBandwidth'] = reader.read1('d')
         handle.seek(i + 392)  # sVmonFiltFrequency = 392; (* LONGREAL *)
         self._temp['sVmonFiltFrequency'] = reader.read1('d')
-
-        handle.seek(i + 264)  # sImon1Bandwidth = 264; (* LONGREAL *)
-        self._temp['sImon1Bandwidth'] = reader.read1('d')
-        handle.seek(i + 304)  # sRsTau = 304; (* LONGREAL *)
-        self._temp['sRsTau'] = reader.read1('d')
 
     def c_fast(self):
         """

--- a/myokit/gui/datalog_viewer.py
+++ b/myokit/gui/datalog_viewer.py
@@ -437,6 +437,7 @@ class DataLogViewer(myokit.gui.MyokitApplication):
 
     def load_dat_file(self, filename):
         """ Loads a PatchMaster dat file. """
+        complete_only = False
 
         pbar = myokit.gui.progress.ProgressBar(
             self, 'Loading groups and series')
@@ -449,11 +450,16 @@ class DataLogViewer(myokit.gui.MyokitApplication):
 
         try:
             with myokit.formats.heka.PatchMasterFile(filename) as f:
-                n = sum([len(list(g.complete_series())) for g in f])
+                if complete_only:
+                    n = sum([len(list(g.complete_series())) for g in f])
+                else:
+                    n = sum(len(g) for g in f)
                 i = 0
                 stop = False
                 for group in f:
-                    for series in group.complete_series():
+                    if complete_only:
+                        group = group.complete_series()
+                    for series in group:
                         self._tabs.addTab(
                             PatchMasterTab(self, series),
                             f'{group.label()} {series.label()}')


### PR DESCRIPTION
@chonlei

This adds some code to deal with the `.amp` segment of a file, and updates the viewer to show incomplete traces (it wasn't showing any for Alex's data, presumably because it couldn't parse the stimulus and so couldn't determine that the traces were from completed recordings).

The code isn't finished.
In particularly, it sticks a load of information in a property called `._temp`.

If you can figure out what these fields (or any others you want to add) mean, what units they're in etc., then we can add proper methods for them (with docstrings that say what they mean).



This script reads a file and prints all the *unparsed* amplifier info (so not the stuff where I actually know exactly what it means):
```
#!/usr/bin/env python3
import myokit
import myokit.formats.heka as heka


files = [
    '220502_008.dat',
]

for fname in files:
    with heka.PatchMasterFile(fname) as f:
        for group in f:
            group_label = group.label()

            print(f'Splitting {group_label} ({fname})')
            count = {}

            for series in group:
                print(f'Series label: {series.label()}')
                for i, a in enumerate(series.amplifier_states()):
                    print(f'Amplifier {i}')
                    for k, v in a._temp.items():
                        print(f'  {k}: {v}')
```