### PR TITLE
Fixed bug in MarkovModel cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This page lists the main changes made to Myokit in each release.
 - Deprecated
 - Removed
 - Fixed
+  - [#1045](https://github.com/myokit/myokit/pull/1045) Fixed an issue where the cache used in MarkovModel was not invalidated if `set_constant()` changed simulation parameters.
 
 ## [1.35.4] - 2023-10-12
 - Added

--- a/myokit/lib/markov.py
+++ b/myokit/lib/markov.py
@@ -1496,6 +1496,8 @@ class DiscreteSimulation:
         Updates a single parameter to a new value.
         """
         self._parameters[self._parameter_map[variable]] = float(value)
+        self._cached_rates = None
+        self._cached_matrix = None
 
     def set_default_state(self, state):
         """

--- a/myokit/lib/markov.py
+++ b/myokit/lib/markov.py
@@ -975,6 +975,10 @@ class AnalyticalSimulation:
         """
         self._parameters[self._parameter_map[variable]] = float(value)
 
+        # Invalidate cache
+        self._cached_matrices = {}
+        self._cached_solution = {}
+
     def set_default_state(self, state):
         """
         Changes this simulation's default state.


### PR DESCRIPTION
set_constant can change parameter values which means the previously cached matrices and solutions are no longer valid (same reasoning as set_parameters which already invalidates the cache).

The cache is now invalidated in set_constant to match set_parameters

Closes #1044