### PR TITLE
Improvements to evaluate_derivatives() methods and cvodes error display.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@ This page lists the main changes made to Myokit in each release.
 
 ## Unreleased
 - Added
+  - [#1051](https://github.com/myokit/myokit/pull/1051) Added a method `Simulation.crash_inputs` that returns the inputs (binding values) if the last run raised a `SimulationError`.
 - Changed
+  - [#1051](https://github.com/myokit/myokit/pull/1051) `Model.evaluate_derivatives` will now use `numpy.errstate(all='raise')` when `ignore_errors` is set to `False`, causing more numerical issues to be reported.
 - Deprecated
+  - [#1051](https://github.com/myokit/myokit/pull/1051) `Simulation.eval_derivatives` is deprecated in favour of an `evaluate_derivatives` method that uses `default_state` instead of `state` when no state is given, and has better support and clearer rules for handling bindings.
+  - [#1051](https://github.com/myokit/myokit/pull/1051) `Simulation.last_state` is deprecated in favour of `crash_state`.
 - Removed
 - Fixed
   - [#1045](https://github.com/myokit/myokit/pull/1045) Fixed an issue where the cache used in MarkovModel was not invalidated if `set_constant()` changed simulation parameters.
+  - [#1050](https://github.com/myokit/myokit/pull/1050) Fixed warnings about unknown escape sequences.
+  - [#1051](https://github.com/myokit/myokit/pull/1051) Numerical simulation errors in `Simulation` now re-evaluate the state using the last inputs, as well as the last state.
 
 ## [1.35.4] - 2023-10-12
 - Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This page lists the main changes made to Myokit in each release.
   - [#1045](https://github.com/myokit/myokit/pull/1045) Fixed an issue where the cache used in MarkovModel was not invalidated if `set_constant()` changed simulation parameters.
   - [#1050](https://github.com/myokit/myokit/pull/1050) Fixed warnings about unknown escape sequences.
   - [#1051](https://github.com/myokit/myokit/pull/1051) Numerical simulation errors in `Simulation` now re-evaluate the state using the last inputs, as well as the last state.
+  - [#1051](https://github.com/myokit/myokit/pull/1051) The `Simulation` class now provides error states and inputs for both cvode-detected crashes and too many zero-length step crashes.
 
 ## [1.35.4] - 2023-10-12
 - Added

--- a/myokit/_model_api.py
+++ b/myokit/_model_api.py
@@ -10,6 +10,8 @@ import re
 
 from collections import OrderedDict
 
+import numpy
+
 import myokit
 
 
@@ -1406,11 +1408,13 @@ class Model(ObjectWithMetaData, VarProvider):
                         value = float('nan')
                     values[eq.lhs] = value
         else:
-            for group in order.values():
-                for eq in group:
-                    if eq.lhs in values:
-                        continue
-                    values[eq.lhs] = eq.rhs.eval(values, precision=precision)
+            with numpy.errstate(all='raise'):
+                for group in order.values():
+                    for eq in group:
+                        if eq.lhs in values:
+                            continue
+                        values[eq.lhs] = eq.rhs.eval(
+                            values, precision=precision)
 
         # Return calculated state
         return [values[state.lhs()] for state in self._state_vars]
@@ -1571,7 +1575,7 @@ class Model(ObjectWithMetaData, VarProvider):
         ``derivatives=None``
             An optional list or other sequence of evaluated derivatives. If not
             given, the values will be calculed from ``state`` using
-            :meth:`eval_derivatives()`.
+            :meth:`evaluate_derivatives()`.
         ``precision=myokit.DOUBLE_PRECISION``
             An optional precision argument to use when evaluating the state
             derivatives, and to pass into :meth:`myokit.float.str` when

--- a/myokit/_sim/cvodessim.c
+++ b/myokit/_sim/cvodessim.c
@@ -196,7 +196,7 @@ union PSys *pacing_systems;   /* Array of pacing systems (event based or time se
 enum PSysType *pacing_types;  /* Array of pacing system types */
 PyObject *protocols;          /* The protocols used to generate the pacing systems */
 double* pacing;               /* Pacing values, same size as pacing_systems and pacing_types */
-int n_pace;                   /* The number of pacing systems */
+int n_pace;                   /* The number of pacing systems: Must be set with every call from Python that uses it */
 
 /*
  * CVODE Memory
@@ -1697,36 +1697,40 @@ sim_step(PyObject *self, PyObject *args)
  * Evaluates the state derivatives at the given state
  */
 PyObject*
-sim_eval_derivatives(PyObject *self, PyObject *args)
+sim_evaluate_derivatives(PyObject *self, PyObject *args)
 {
     /* Declare variables here for C89 compatibility */
     int i;
     int success;
     double time_in;
+    double realtime_in;
+    double evaluations_in;
     PyObject *pace_in;
-    double *pacing_in;
-    Model model;
-    Model_Flag flag_model;
-    PyObject *state;
-    PyObject *deriv;
+    double *pacing_values;
     PyObject *literals;
     PyObject *parameters;
+    PyObject *state;
+    PyObject *deriv;
     PyObject *val;
+    Model model;
+    Model_Flag flag_model;
 
     /* Start */
     success = 0;
 
     /* Check input arguments */
     /* Check input arguments     0123456789ABCDEF*/
-    if (!PyArg_ParseTuple(args, "dOOOOO",
+    if (!PyArg_ParseTuple(args, "dOddOOOO",
             &time_in,           /* 0. Float: time */
-            &pace_in,           /* 1. List: pace */
-            &state,             /* 2. List: state */
-            &deriv,             /* 3. List: store derivatives here */
+            &pace_in,           /* 1. List: pacing values */
+            &realtime_in,       /* 2. Float: realtime */
+            &evaluations_in,    /* 3. Float: evaluations */
             &literals,          /* 4. List: literal constant values */
-            &parameters         /* 5. List: parameter values */
-            )) {
-        PyErr_SetString(PyExc_Exception, "Incorrect input arguments in sim_eval_derivatives.");
+            &parameters,        /* 5. List: parameter values */
+            &state,             /* 6. List: state */
+            &deriv              /* 7. List: store derivatives here */
+    )) {
+        PyErr_SetString(PyExc_Exception, "Incorrect input arguments in sim_evaluate_derivatives.");
         /* Nothing allocated yet, no pyobjects _created_, return directly */
         return 0;
     }
@@ -1736,20 +1740,20 @@ sim_eval_derivatives(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_Exception, "Pace argument must be a list.");
         return 0;
     }
-    if (!PyList_Check(state)) {
-        PyErr_SetString(PyExc_Exception, "State argument must be a list.");
-        return 0;
-    }
-    if (!PyList_Check(deriv)) {
-        PyErr_SetString(PyExc_Exception, "Derivatives argument must be a list.");
-        return 0;
-    }
     if (!PyList_Check(literals)) {
         PyErr_SetString(PyExc_Exception, "Literals argument must be a list.");
         return 0;
     }
     if (!PyList_Check(parameters)) {
         PyErr_SetString(PyExc_Exception, "Parameters argument must be a list.");
+        return 0;
+    }
+    if (!PyList_Check(state)) {
+        PyErr_SetString(PyExc_Exception, "State argument must be a list.");
+        return 0;
+    }
+    if (!PyList_Check(deriv)) {
+        PyErr_SetString(PyExc_Exception, "Derivatives argument must be a list.");
         return 0;
     }
 
@@ -1767,6 +1771,8 @@ sim_eval_derivatives(PyObject *self, PyObject *args)
         goto error;
     }
 
+    /* Set up pacing (but without protocols) */
+    n_pace = (int)PyList_Size(pace_in);
     flag_model = Model_SetupPacing(model, n_pace);
     if (flag_model != Model_OK) {
         Model_SetPyErr(flag_model);
@@ -1774,18 +1780,23 @@ sim_eval_derivatives(PyObject *self, PyObject *args)
     }
 
     /* Set pacing values */
-    pacing_in = (double*)malloc((size_t)n_pace * sizeof(double));
+    pacing_values = (double*)malloc((size_t)n_pace * sizeof(double));
     for (i=0; i<n_pace; i++) {
         val = PyList_GetItem(pace_in, i); /* Don't decref */
         if (!PyFloat_Check(val)) {
             PyErr_Format(PyExc_Exception, "Item %d in pace vector is not a float.", i);
             goto error;
         }
-        pacing_in[i] = PyFloat_AsDouble(val);
+        pacing_values[i] = PyFloat_AsDouble(val);
     }
 
     /* Set bound variables */
-    Model_SetBoundVariables(model, (realtype)time_in, (realtype*)pacing_in, 0, 0);
+    Model_SetBoundVariables(
+        model,
+        (realtype)time_in,
+        (realtype*)pacing_values, 
+        (realtype)realtime_in, 
+        (realtype)evaluations_in);
 
     /* Set literal values */
     for (i=0; i<model->n_literals; i++) {
@@ -1925,7 +1936,7 @@ PyMethodDef SimMethods[] = {
     {"sim_init", sim_init, METH_VARARGS, "Initialize the simulation."},
     {"sim_step", sim_step, METH_VARARGS, "Perform the next step in the simulation."},
     {"sim_clean", py_sim_clean, METH_VARARGS, "Clean up after an aborted simulation."},
-    {"eval_derivatives", sim_eval_derivatives, METH_VARARGS, "Evaluate the state derivatives."},
+    {"evaluate_derivatives", sim_evaluate_derivatives, METH_VARARGS, "Evaluate the state derivatives."},
     {"set_tolerance", sim_set_tolerance, METH_VARARGS, "Set the absolute and relative solver tolerance."},
     {"set_max_step_size", sim_set_max_step_size, METH_VARARGS, "Set the maximum solver step size (0 for none)."},
     {"set_min_step_size", sim_set_min_step_size, METH_VARARGS, "Set the minimum solver step size (0 for none)."},

--- a/myokit/_sim/cvodessim.py
+++ b/myokit/_sim/cvodessim.py
@@ -909,7 +909,7 @@ class Simulation(myokit.CModule):
 
                 # Store error state
                 self._error_state = state
-                self._error_inputs = {'time': myokit.float.str(bound[0])}
+                self._error_inputs = {'time': bound[0]}
                 for i, label in enumerate(('realtime', 'evaluations')):
                     if self._model.binding(label) is not None:
                         self._error_inputs[label] = bound[1 + i]
@@ -918,7 +918,8 @@ class Simulation(myokit.CModule):
 
                 # Create long error message
                 txt = ['A numerical error occurred during simulation at'
-                       ' t = ' + str(t) + '.', 'Last reached state: ']
+                       ' t = ' + myokit.float.str(t) + '.',
+                       'Last reached state: ']
                 txt.extend(['  ' + x for x
                             in self._model.format_state(state).splitlines()])
                 txt.append('Inputs for binding:')

--- a/myokit/_sim/cvodessim.py
+++ b/myokit/_sim/cvodessim.py
@@ -238,6 +238,7 @@ class Simulation(myokit.CModule):
 
         # Last state reached before error
         self._error_state = None
+        self._error_inputs = None
 
         # Starting time
         self._time = 0
@@ -387,6 +388,28 @@ class Simulation(myokit.CModule):
         finally:
             myokit.tools.rmtree(d_build, silent=True)
 
+    def crash_inputs(self):
+        """
+        If the last call to :meth:`Simulation.pre()` or
+        :meth:`Simulation.run()` resulted in an error, this will return the
+        last "inputs" (time, pace, etc) reached during that simulation.
+
+        Will return ``None`` if no simulation was run or the simulation did not
+        result in an error.
+        """
+        return dict(self._error_inputs) if self._error_inputs else None
+
+    def crash_state(self):
+        """
+        If the last call to :meth:`Simulation.pre()` or
+        :meth:`Simulation.run()` resulted in an error, this will return the
+        last state reached during that simulation.
+
+        Will return ``None`` if no simulation was run or the simulation did not
+        result in an error.
+        """
+        return list(self._error_state) if self._error_state else None
+
     def default_state(self):
         """
         Returns the default state.
@@ -402,60 +425,83 @@ class Simulation(myokit.CModule):
             return [list(x) for x in self._s_default_state]
         return None
 
-    def last_state(self):
-        """
-        If the last call to :meth:`Simulation.pre()` or
-        :meth:`Simulation.run()` resulted in an error, this will return the
-        last state reached during that simulation.
-
-        Will return ``None`` if no simulation was run or the simulation did not
-        result in an error.
-        """
-        return list(self._error_state) if self._error_state else None
-
     def eval_derivatives(self, y=None, pacing=None):
         """
-        Evaluates and returns the state derivatives.
+        Deprecated alias of :meth:`evaluate_derivatives`.
 
-        The state to evaluate for can be given as ``y``. If no state is given
-        the current simulation state is used.
+        Note that while :meth:`eval_derivatives` used the :meth:`state()` as
+        default, the new method uses :meth:`default_state()`.
+        """
+        # Deprecated on 2024-03-08
+        import warnings
+        warnings.warn(
+            'The method `myokit.Simulation.eval_derivatives` is deprecated,'
+            ' please use `evaluate_derivatives(state=sim.state())` instead.'
+        )
+        if y is None:
+            y = self.state()
+        return self.evaluate_derivatives(y, pacing)
 
-        An optional dict ``pacing`` can be passed in that maps labels to
-        numerical values. If a label is used but not provided in ``pacing``,
-        it's value will be set to 0.
+    def evaluate_derivatives(self, state=None, inputs=None):
+        """
+        Evaluates and returns the state derivatives for the given ``state`` and
+        ``inputs``.
+
+        If no ``state`` is given, the value returned by :meth:`default_state()`
+        is used.
+
+        An optional dict ``inputs`` can be passed in to set the values of
+        time and other inputs (e.g. pacing values). If "time" is not set in
+        ``inputs``, the value 0 will be used, regardless of the current
+        simulation. Similarly, if pacing values are not set in ``inputs``, 0
+        will be used regardless of the protocols or the current time.
+
+        If any variables have been changed with `set_constant` their new value
+        will be used.
         """
         # Get state
-        if y is None:
-            y = list(self._state)
+        if state is None:
+            y = list(self._default_state)
         else:
-            y = self._model.map_to_state(y)
+            y = self._model.map_to_state(state)
 
+        # Get inputs
+        time = realtime = evaluations = 0
         pacing_values = [0.0] * len(self._pacing_labels)
-        if pacing is not None:
-            for k, v in pacing.items():
+        if inputs is not None:
+            if 'time' in inputs:
+                time = float(inputs['time'])
+                del inputs['time']
+            if 'realtime' in inputs:  # User really shouldn't, but can do this
+                realtime = float(inputs['realtime'])
+                del inputs['realtime']
+            if 'evaluations' in inputs:
+                evaluations = float(inputs['evaluations'])
+                del inputs['evaluations']
+            for k, v in inputs.items():
                 try:
                     ki = self._pacing_labels.index(k)
-                    pacing_values[ki] = float(v)
                 except ValueError:
-                    pass
+                    raise ValueError(f'Unknown binding or pacing label `{k}`.')
+                pacing_values[ki] = float(v)
+
+        # Literals and parameters: Can be changed with set_constant
+        literals = list(self._literals.values())
+        parameters = list(self._parameters.values())
 
         # Create space to store derivatives
         dy = list(self._state)
 
         # Evaluate and return
-        self._sim.eval_derivatives(
-            # 0. Time
-            0,
-            # 1. Pace
-            pacing_values,
-            # 2. State
-            y,
-            # 3. Space to store the state derivatives
-            dy,
-            # 4. Literal values
-            list(self._literals.values()),
-            # 5. Parameter values
-            list(self._parameters.values()),
+        self._sim.evaluate_derivatives(
+            time,               # 0. Time
+            pacing_values,      # 1. Pacing values
+            realtime,           # 2. Realtime
+            evaluations,        # 3. Evaluations
+            literals,           # 4. Literals
+            parameters,         # 5. Parameters
+            y,                  # 6. State
+            dy,                 # 7. Derivatives (out)
         )
         return dy
 
@@ -472,6 +518,21 @@ class Simulation(myokit.CModule):
         simulation.
         """
         return self._sim.number_of_steps()
+
+    def last_state(self):
+        """
+        If the last call to :meth:`Simulation.pre()` or
+        :meth:`Simulation.run()` resulted in an error, this will return the
+        last state reached during that simulation.
+
+        Will return ``None`` if no simulation was run or the simulation did not
+        result in an error.
+        """
+        # Deprecated on 2024-03-08
+        import warnings
+        warnings.warn('The method `myokit.Simulation.last_state` is'
+                      ' deprecated. Please use `crash_state` instead.')
+        return self.crash_state()
 
     def pre(self, duration, progress=None, msg='Pre-pacing simulation'):
         """
@@ -690,6 +751,7 @@ class Simulation(myokit.CModule):
 
         # Reset error state
         self._error_state = None
+        self._error_inputs = None
 
         # Simulation times
         if duration < 0:
@@ -847,6 +909,12 @@ class Simulation(myokit.CModule):
 
                 # Store error state
                 self._error_state = state
+                self._error_inputs = {'time': myokit.float.str(bound[0])}
+                for i, label in enumerate(('realtime', 'evaluations')):
+                    if self._model.binding(label) is not None:
+                        self._error_inputs[label] = bound[1 + i]
+                for i, label in enumerate(self._pacing_labels):
+                    self._error_inputs[label] = bound[3 + i]
 
                 # Create long error message
                 txt = ['A numerical error occurred during simulation at'
@@ -854,19 +922,14 @@ class Simulation(myokit.CModule):
                 txt.extend(['  ' + x for x
                             in self._model.format_state(state).splitlines()])
                 txt.append('Inputs for binding:')
-                txt.append('  time        = ' + myokit.float.str(bound[0]))
-                txt.append('  realtime    = ' + myokit.float.str(bound[1]))
-                txt.append('  evaluations = ' + myokit.float.str(bound[2]))
-                for i, label in enumerate(self._pacing_labels):
-                    txt.append(
-                        '  ' + label + ' = ' + myokit.float.str(bound[3 + i])
-                    )
+                for key, value in self._error_inputs.items():
+                    txt.append(f'  {key} = {myokit.float.str(value)}')
                 txt.append(str(e))
 
                 # Check if state derivatives can be evaluated in Python, if
                 # not, add the error to the error message.
                 try:
-                    self._model.evaluate_derivatives(state)
+                    self._model.evaluate_derivatives(state, self._error_inputs)
                 except Exception as en:
                     txt.append(str(en))
 

--- a/myokit/tests/test_simulation_cvodes.py
+++ b/myokit/tests/test_simulation_cvodes.py
@@ -591,59 +591,93 @@ class SimulationTest(unittest.TestCase):
         self.assertEqual(s[0][0], 1)
         self.assertEqual(s[1][0], 0)
 
-    def test_eval_derivatives(self):
+    def test_evaluate_derivatives(self):
         # Test :meth:`Simulation.eval_derivatives()`.
 
-        self.sim.reset()
-        s1 = self.sim.state()
-        d1 = self.sim.eval_derivatives()
-        self.sim.run(1)
-        d2 = self.sim.eval_derivatives()
-        self.assertNotEqual(d1, d2)
-        self.assertEqual(d1, self.sim.eval_derivatives(s1))
-        self.sim.set_state(s1)
-        self.assertEqual(d1, self.sim.eval_derivatives())
+        m = myokit.Model()
+        z = m.add_component('z')
+        t = z.add_variable('t', rhs=0, binding='time')
+        a = z.add_variable('a', rhs=1, binding='pace')
+        b = z.add_variable('b', rhs=2, binding='pace1')
+        c = z.add_variable('c', rhs=4, binding='pace2')
+        d = z.add_variable('d', rhs=8, binding='evaluations')
+        e = z.add_variable('e', rhs=12, binding='realtime')
+        f = z.add_variable('f', rhs=100)
+        p = z.add_variable('p', rhs='p+t+a+b+c+d+e+f', initial_value=0)
+        q = z.add_variable('q', rhs='p + q', initial_value=1)
 
-    def test_eval_derivatives_with_pacing(self):
-        # Test :meth:`Simulation.eval_derivatives()`.
+        sim = myokit.Simulation(m)
 
-        model = myokit.Model()
-        c = model.add_component('c')
+        # Test without input
+        self.assertEqual(sim.evaluate_derivatives(), [106, 1])
 
-        a = c.add_variable('a')
-        a.set_binding('a')
-        a.set_rhs(0)
-        b = c.add_variable('b')
-        b.set_binding('b')
-        b.set_rhs(0)
+        # Test with new state
+        self.assertEqual(sim.evaluate_derivatives([1, 2]), [107, 3])
 
-        y = c.add_variable('y')
-        t = c.add_variable('t')
-        t.set_binding('time')
-        t.set_rhs(0)
-        y.promote(1)
-        y.set_rhs('- a * y - b * y')
+        # Test with changed constant
+        sim.set_constant('z.f', 200)
+        self.assertEqual(sim.evaluate_derivatives(), [206, 1])
+        sim.set_constant('z.f', 300)
+        self.assertEqual(sim.evaluate_derivatives([1, 2]), [307, 3])
+        sim.set_constant('z.f', 0)
+        self.assertEqual(sim.evaluate_derivatives([1, 2]), [7, 3])
 
-        pa = myokit.Protocol()
-        pa.schedule(1, 0, 0.5)
+        # Test with inputs
+        d = {'time': 1}
+        self.assertEqual(sim.evaluate_derivatives([1, 2], d), [8, 3])
+        d = {'time': 2}
+        self.assertEqual(sim.evaluate_derivatives([1, 2], d), [9, 3])
+        d = {'time': 2, 'evaluations': 3}
+        self.assertEqual(sim.evaluate_derivatives([1, 2], d), [12, 3])
+        d = {'time': 2, 'evaluations': 3, 'realtime': 1.23}
+        self.assertEqual(sim.evaluate_derivatives([1, 2], d), [13.23, 3])
 
-        pb = myokit.Protocol()
-        pb.schedule(2, 1.0, 0.5)
+        # Test with unknown inputs
+        d = {'toime': 1}
+        self.assertRaisesRegex(ValueError, 'Unknown binding or',
+                               sim.evaluate_derivatives, [1, 2], d)
 
-        sim = myokit.Simulation(model, {'a': pa, 'b': pb})
+        # Test with pacing: not passed on to sim
+        sim.set_protocol(myokit.pacing.constant(1000))
+
+        # Running doesn't change anything
+        self.assertEqual(sim.evaluate_derivatives(), [6, 1])
         sim.run(1)
-        d1 = sim.eval_derivatives(pacing={'a': 0.5, 'b': 0.5})
-        d2 = sim.eval_derivatives(pacing={'a': 1.5, 'b': 0.5})
-        self.assertNotEqual(d1, d2)
-        d1 = sim.eval_derivatives(pacing={'b': 0.5})
-        d2 = sim.eval_derivatives(pacing={'a': 0.0, 'b': 0.5})
-        self.assertEqual(d1, d2)
-        d1 = sim.eval_derivatives()
-        d2 = sim.eval_derivatives(pacing={'a': 0.0, 'b': 0.0})
-        self.assertEqual(d1, d2)
-        d1 = sim.eval_derivatives(pacing={'a': 0.0, 'b': 0.5})
-        d2 = sim.eval_derivatives(pacing={'aaaaa': 1.0, 'b': 0.5})
-        self.assertEqual(d1, d2)
+        self.assertEqual(sim.evaluate_derivatives(), [6, 1])
+        self.assertEqual(sim.evaluate_derivatives([2, 3]), [8, 5])
+        sim.run(10)
+        self.assertEqual(sim.evaluate_derivatives(), [6, 1])
+        self.assertEqual(sim.evaluate_derivatives([2, 3]), [8, 5])
+        sim.reset()
+        self.assertEqual(sim.evaluate_derivatives([2, 3]), [8, 5])
+        d = {'time': 123}
+        self.assertEqual(sim.evaluate_derivatives([2, 3], d), [131, 5])
+
+        # Changing the pacing labels
+        d = {'pace': 1000}
+        self.assertEqual(sim.evaluate_derivatives(inputs=d), [1006, 1])
+        d = {'pace1': 1}
+        self.assertRaisesRegex(ValueError, 'Unknown binding or',
+                               sim.evaluate_derivatives, inputs=d)
+
+        sim = myokit.Simulation(m, {
+            'pace1': myokit.pacing.constant(1000),
+            'pace2': myokit.pacing.constant(2000)})
+        d = {'pace': 1}
+        self.assertRaisesRegex(ValueError, 'Unknown binding or',
+                               sim.evaluate_derivatives, [1, 2], d)
+        self.assertEqual(sim.evaluate_derivatives(), [101, 1])
+        d = {'pace1': 100}
+        self.assertEqual(sim.evaluate_derivatives(inputs=d), [201, 1])
+        d = {'pace2': 200}
+        self.assertEqual(sim.evaluate_derivatives(inputs=d), [301, 1])
+        d = {'pace1': 123, 'pace2': 200}
+        self.assertEqual(sim.evaluate_derivatives(inputs=d), [424, 1])
+
+        d1 = self.sim.evaluate_derivatives()
+        with WarningCollector() as w:
+            self.assertEqual(self.sim.eval_derivatives(), d1)
+        self.assertIn('eprecated', w.text())
 
     def test_sensitivities_initial(self):
         # Test setting initial sensitivity values.


### PR DESCRIPTION
Simulation
- Renamed `last_state` to `crash_state` to differentiate from `last_number_of_steps` etc.
- Added a `crash_inputs` to get the bindings, and updated the simulation error handling to use the exact bindings when trying to reproduce the error in Python
- Renamed `Simulation.eval_derivatives` to `evaluate_derivatives` and made it use the default_state instead of state (if no state is specified), to be more consistent (binding values were already not used, regardless of their current values). Upgrade the binding handling so that time etc can be set.
Model
- Made `model.evaluate_derivatives` use an `np.errstate(all='raise')` (when not explicitly ignoring errors) to catch more numerical issues