### PR TITLE
DataLog: Ignore byte order marker (ufeff) at start of csv file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,15 @@ This page lists the main changes made to Myokit in each release.
 - Removed
 - Fixed
   - [#1083](https://github.com/myokit/myokit/pull/1083) Fixed bug when passing initial state `Expression` objects to `myokit.step`.
+  - [#1093](https://github.com/myokit/myokit/pull/1093) `DataLog.load_csv` will now ignore an initial byte order marker.
 
 ## [1.37.0] - 2024-06-17
 - Added
   - [#1075](https://github.com/myokit/myokit/pull/1075) Add a `myokit.TypeError` exception, which inherits from `myokit.IntegrityError` but is used specifically if one type of expression was expected but another was found.
 - Changed
-  - [#1075](https://github.com/myokit/myokit/pull/1075) Expressions will now raise a `myokit.TypeError` in the constructor if their operands are unexpected expression types, e.g. if numbers and booleans are mixed.
-  - [#1074](https://github.com/myokit/myokit/pull/1074) Expressions will now raise a `myokit.IntegrityError` in the constructor if their operands are not expression objects: previously, this check was only performed by `Expression.validate()`.
   - [#1067](https://github.com/myokit/myokit/pull/1067) Improved the meta data loaded from HEKA files when creating a `myokit.DataLog`.
+  - [#1074](https://github.com/myokit/myokit/pull/1074) Expressions will now raise a `myokit.IntegrityError` in the constructor if their operands are not expression objects: previously, this check was only performed by `Expression.validate()`.
+  - [#1075](https://github.com/myokit/myokit/pull/1075) Expressions will now raise a `myokit.TypeError` in the constructor if their operands are unexpected expression types, e.g. if numbers and booleans are mixed.
 - Removed
   - [#1075](https://github.com/myokit/myokit/pull/1075) Removed the `PrefixCondition` base class previously used in the expression system, as only `Not` inherited from it.
 - Fixed

--- a/myokit/_datalog.py
+++ b/myokit/_datalog.py
@@ -702,6 +702,10 @@ class DataLog(OrderedDict):
             # Read first line
             line = f.readline()
 
+            # Ignore byte order marker (BOM)
+            if line[:1] == '\ufeff':
+                line = line[1:]
+
             # Ignore comments
             while line.lstrip()[:1] == '#':
                 line = f.readline()

--- a/myokit/_datalog.py
+++ b/myokit/_datalog.py
@@ -694,19 +694,23 @@ class DataLog(OrderedDict):
                 + str(1 + char) + ': ' + msg)
 
         # Detect Microsoft's annyoing utf-8-sig encoding
-        encoding = None
-        with open(filename, 'r', newline=None) as f:
-            if f.read(1) == '\ufeff':
-                encoding = 'utf-8-sig'
+        #encoding = None
+        #with open(filename, 'r', newline=None) as f:
+        #    if f.read(1) == '\ufeff':
+        #        encoding = 'utf-8-sig'
 
         quote = '"'
         delim = ','
-        with open(filename, 'r', newline=None, encoding=encoding) as f:
+        with open(filename, 'r', newline=None, encoding) as f:
             # Read header
             keys = []   # The log keys, in order of appearance
 
             # Read first line
             line = f.readline()
+
+            # Ignore windows' annoying byte order marker
+            if line[:1] = '\ufeff':
+                line = line[1:]
 
             # Ignore comments
             while line.lstrip()[:1] == '#':

--- a/myokit/_datalog.py
+++ b/myokit/_datalog.py
@@ -694,23 +694,22 @@ class DataLog(OrderedDict):
                 + str(1 + char) + ': ' + msg)
 
         # Detect Microsoft's annyoing utf-8-sig encoding
-        #encoding = None
-        #with open(filename, 'r', newline=None) as f:
-        #    if f.read(1) == '\ufeff':
-        #        encoding = 'utf-8-sig'
+        # Note: We have to perform the first read in utf-8 mode, because the
+        # default encoding on windows will turn the BOM into a different set of
+        # characters, so that f.read(1) won't actually equal \ufeff
+        encoding = None
+        with open(filename, 'r', encoding='utf-8') as f:
+            if f.read(1) == '\ufeff':
+                encoding = 'utf-8-sig'
 
         quote = '"'
         delim = ','
-        with open(filename, 'r', newline=None) as f:
+        with open(filename, 'r', newline=None, encoding=encoding) as f:
             # Read header
             keys = []   # The log keys, in order of appearance
 
             # Read first line
             line = f.readline()
-
-            # Ignore windows' annoying byte order marker
-            if line[:1] = '\ufeff':
-                line = line[1:]
 
             # Ignore comments
             while line.lstrip()[:1] == '#':

--- a/myokit/_datalog.py
+++ b/myokit/_datalog.py
@@ -693,18 +693,20 @@ class DataLog(OrderedDict):
                 'Syntax error on line ' + str(line) + ', character '
                 + str(1 + char) + ': ' + msg)
 
+        # Detect Microsoft's annyoing utf-8-sig encoding
+        encoding = None
+        with open(filename, 'r', newline=None) as f:
+            if f.read(1) == '\ufeff':
+                encoding = 'utf-8-sig'
+
         quote = '"'
         delim = ','
-        with open(filename, 'r', newline=None) as f:
+        with open(filename, 'r', newline=None, encoding=encoding) as f:
             # Read header
             keys = []   # The log keys, in order of appearance
 
             # Read first line
             line = f.readline()
-
-            # Ignore byte order marker (BOM)
-            if line[:1] == '\ufeff':
-                line = line[1:]
 
             # Ignore comments
             while line.lstrip()[:1] == '#':

--- a/myokit/_datalog.py
+++ b/myokit/_datalog.py
@@ -701,7 +701,7 @@ class DataLog(OrderedDict):
 
         quote = '"'
         delim = ','
-        with open(filename, 'r', newline=None, encoding) as f:
+        with open(filename, 'r', newline=None) as f:
             # Read header
             keys = []   # The log keys, in order of appearance
 

--- a/myokit/tests/test_datalog.py
+++ b/myokit/tests/test_datalog.py
@@ -698,9 +698,8 @@ class DataLogTest(unittest.TestCase):
 
         with TemporaryDirectory() as td:
             path = td.path('test.csv')
-            with open(path, 'w') as f:
-                f.write('\ufefftime,x\n')
-                f.write('0,2\n1,3\n')
+            with open(path, 'wb') as f:
+                f.write('time,x\n0,2\n1,3\n'.encode('utf-8-sig'))
             d = myokit.DataLog.load_csv(path)
             self.assertEqual(len(d), 2)
             self.assertEqual(list(d.keys()), ['time', 'x'])

--- a/myokit/tests/test_datalog.py
+++ b/myokit/tests/test_datalog.py
@@ -698,8 +698,8 @@ class DataLogTest(unittest.TestCase):
 
         with TemporaryDirectory() as td:
             path = td.path('test.csv')
-            with open(path, 'wb') as f:
-                f.write('time,x\n0,2\n1,3\n'.encode('utf-8-sig'))
+            with open(path, 'w', encoding='utf-8-sig') as f:
+                f.write('time,x\n0,2\n1,3\n')
             d = myokit.DataLog.load_csv(path)
             self.assertEqual(len(d), 2)
             self.assertEqual(list(d.keys()), ['time', 'x'])

--- a/myokit/tests/test_datalog.py
+++ b/myokit/tests/test_datalog.py
@@ -703,7 +703,7 @@ class DataLogTest(unittest.TestCase):
                 f.write('0,2\n1,3\n')
             d = myokit.DataLog.load_csv(path)
             self.assertEqual(len(d), 2)
-            self.assertEqual(list(d.keys()), 'time')
+            self.assertEqual(list(d.keys()), ['time', 'x'])
 
     def test_load_csv_errors(self):
         # Test for errors during csv loading.

--- a/myokit/tests/test_datalog.py
+++ b/myokit/tests/test_datalog.py
@@ -701,7 +701,6 @@ class DataLogTest(unittest.TestCase):
             with open(path, 'w', encoding='utf-8-sig') as f:
                 f.write('time,x\n0,2\n1,3\n')
             d = myokit.DataLog.load_csv(path)
-            self.assertEqual(len(d), 2)
             self.assertEqual(list(d.keys()), ['time', 'x'])
 
     def test_load_csv_errors(self):

--- a/myokit/tests/test_datalog.py
+++ b/myokit/tests/test_datalog.py
@@ -693,6 +693,18 @@ class DataLogTest(unittest.TestCase):
             list(d.keys()),
             ['time', 'x-1', 'x-3', 'ys-2-1', 'x-4', 'ys-2-2', 'x-2'])
 
+    def test_load_csv_ufeff(self):
+        # Test ignoring byte order marker (BOM) at start of file
+
+        with TemporaryDirectory() as td:
+            path = td.path('test.csv')
+            with open(path, 'w') as f:
+                f.write('\ufefftime,x\n')
+                f.write('0,2\n1,3\n')
+            d = myokit.DataLog.load_csv(path)
+            self.assertEqual(len(d), 2)
+            self.assertEqual(list(d.keys()), 'time')
+
     def test_load_csv_errors(self):
         # Test for errors during csv loading.
 


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Byte_order_mark
