### PR TITLE
bug: remove auto-register for Unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ This page lists the main changes made to Myokit in each release.
 ## Unreleased
 - Added
 - Changed
+  - [#1116](https://github.com/myokit/myokit/pull/1116) Unit names passed to `Unit.register` are now validated using `myokit.check_name`, and the fourth argument to `Unit.register` is now called `preferred_representation`.
+  - [#1116](https://github.com/myokit/myokit/pull/1116) The method `Unit.register_preferred_representation` now checks that the given representation parses to the given unit.
 - Deprecated
 - Removed
 - Fixed
+  - [#1116](https://github.com/myokit/myokit/pull/1116) Fixed issue where units were represented with double multipliers, e.g. ``[m (0.001) (1e-3)]``.
 
 ## [1.37.2] - 2025-01-09
 - Added

--- a/myokit/_unit.py
+++ b/myokit/_unit.py
@@ -616,7 +616,8 @@ class Unit:
 
     def __str__(self):
 
-        # Strategy 1: Try simple look-up (using float.eq comparison)
+        # Strategy 1: Try simple look-up (using hash based on _str() followed
+        # by check of exponents in __eq__ for comparison
         try:
             return '[' + Unit._preferred_representations[self] + ']'
         except KeyError:
@@ -655,6 +656,11 @@ class Unit:
         # Strategy 4: Build a new representation
         if rep is None:
             rep = self._str(True)
+
+        # Store new representation, unless it contains a multiplier, see
+        # https://github.com/myokit/myokit/issues/1115
+        if '(' not in rep:
+            Unit._preferred_representations[self] = rep[1:-1]
 
         return rep
 

--- a/myokit/_unit.py
+++ b/myokit/_unit.py
@@ -487,56 +487,55 @@ class Unit:
         return self.__rtruediv__(other)
 
     @staticmethod
-    def register(name, unit, quantifiable=False, output=False):
+    def register(name, unit, quantifiable=False,
+                 preferred_representation=False):
         """
-        Registers a unit name with the Unit class. Registered units will be
-        recognised by the parse() method.
+        Registers a unit name with the :class:`Unit` class so that it will be
+        recognised when parsing.
 
         Arguments:
 
         ``name``
-            The unit name. A variable will be created using this name.
+            The unit name. This must be a valid myokit name, i.e.
+            ``myokit.check_name(name)`` should not raise any errors.
         ``unit``
             A valid unit object
         ``quantifiable``
             ``True`` if this unit should be registered with the unit class as a
-            quantifiable unit. Typically this should only be done for the
-            unquantified symbol notation of SI or SI derived units. For example
-            m, g, Hz, N but not meter, kg, hertz or forthnight.
-        ``output``
-            ``True`` if this units name should be used to display this unit in.
-            This should be set for all common units (m, kg, nm, Hz) but not for
-            more obscure units (furlong, parsec). Having ``output`` set to
-            ``False`` will cause one-way behavior: Myokit will recognise the
-            unit name but never use it in output.
-            Setting this to ``True`` will also register the given name as a
-            preferred representation format.
+            _quantifiable_ unit, i.e. a unit that can be preceded by an SI
+            prefix such as "m" or "G". Typically this should only be done
+            for the unquantified symbol notation of SI or SI derived units. For
+            example "m", "g", or "Hz" but not "km", "meter", or "bushel".
+        ``preferred_representation``
+            Set to ``True`` to also register ``name`` as the preferred
+            representation for ``unit``.
 
         """
-        if not isinstance(name, str):
-            raise TypeError('Given name must be a string.')
+        name = myokit.check_name(name)
         if not isinstance(unit, Unit):
             raise TypeError('Given unit must be myokit.Unit')
         Unit._units[name] = unit
         if quantifiable:
             # Overwrite existing entries without warning
             Unit._quantifiable.add(name)
-        if output:
+        if preferred_representation:
             # Overwrite existing entries without warning
             Unit._preferred_representations[unit] = name
 
     @staticmethod
     def register_preferred_representation(rep, unit):
         """
-        Registers a preferred representation for the given unit without
-        registering it as a new type. This method can be used to register
-        common representations such as "umol/L" and "km/h".
+        Sets the preferred representation for the a unit, in terms of already
+        defined units.
+
+        This method can be used to register common representations such as
+        "umol/L" and "km/h". The given representation should be parseable by
+        Myokit, with the result equalling ``unit``.
 
         Arguments:
 
         ``rep``
-            A string, containing the preferred name for this unit. This should
-            be something that Myokit can parse.
+            A string containing the preferred representation for this unit.
         ``unit``
             The unit to register a notation for.
 
@@ -545,9 +544,14 @@ class Unit:
         # Overwrite existing entries without warning
         if not isinstance(unit, myokit.Unit):
             raise ValueError(
-                'Second argument to register_preferred_representation must be'
-                ' a myokit.Unit')
-        Unit._preferred_representations[unit] = str(rep)
+                'The second argument to register_preferred_representation must'
+                ' be a myokit.Unit')
+        rep = str(rep)
+        if not myokit.parse_unit(rep) == unit:
+            raise ValueError(
+                f'The representation [{rep}] does not equal {unit._str(True)}'
+                ' when parsed.')
+        Unit._preferred_representations[unit] = rep
 
     def __repr__(self):
         """
@@ -630,8 +634,8 @@ class Unit:
                 rep = '[' + test + ']'
                 break
 
-        # Strategy 3: Try finding a representation for the exponent and adding
-        # a multiplier to that.
+        # Strategy 3: Try finding a representation for the exponent (without a
+        # multiplier) and adding a multiplier to that.
         if rep is None:
 
             # Because kilos are defined with a multiplier of 1000, the
@@ -641,27 +645,27 @@ class Unit:
             u = Unit(list(self._x), m)
             rep = Unit._preferred_representations.get(u, None)
 
-            # Add multiplier part
+            # Add multiplier part:
             if rep is not None:
-                m = myokit.float.cround(self._m - m)
-                m = 10**m
-                if m >= 1:
-                    m = myokit.float.cround(m)
-                if m < 1e6:
-                    m = str(m)
+                if '(' in rep:
+                    rep = None
                 else:
-                    m = '{:<1.0e}'.format(m)
-                rep = '[' + rep + ' (' + m + ')]'
+                    m = myokit.float.cround(self._m - m)
+                    m = 10**m
+                    if m >= 1:
+                        m = myokit.float.cround(m)
+                    if m < 1e6:
+                        m = str(m)
+                    else:
+                        m = '{:<1.0e}'.format(m)
+                    rep = '[' + rep + ' (' + m + ')]'
 
         # Strategy 4: Build a new representation
         if rep is None:
             rep = self._str(True)
 
-        # Store new representation, unless it contains a multiplier, see
-        # https://github.com/myokit/myokit/issues/1115
-        if '(' not in rep:
-            Unit._preferred_representations[self] = rep[1:-1]
-
+        # Store new representation and return
+        Unit._preferred_representations[self] = rep[1:-1]
         return rep
 
     def __truediv__(self, other):

--- a/myokit/_unit.py
+++ b/myokit/_unit.py
@@ -656,8 +656,6 @@ class Unit:
         if rep is None:
             rep = self._str(True)
 
-        # Store new representation and return
-        Unit._preferred_representations[self] = rep[1:-1]
         return rep
 
     def __truediv__(self, other):

--- a/myokit/tests/test_quantity.py
+++ b/myokit/tests/test_quantity.py
@@ -107,10 +107,10 @@ class QuantityTest(unittest.TestCase):
         # Test has does not change in quantity's lifetime
 
         try:
-            u = myokit.units.m**8
+            u = myokit.units.m / myokit.units.mol
             q1 = myokit.Quantity(1, u)
             h1 = hash(q1)
-            myokit.Unit.register_preferred_representation('abc', u)
+            myokit.Unit.register_preferred_representation('km/kmol', u)
             q2 = myokit.Quantity(1, u)
             h2 = hash(q2)
             self.assertEqual(h1, h2)

--- a/myokit/tests/test_unit.py
+++ b/myokit/tests/test_unit.py
@@ -365,6 +365,18 @@ class MyokitUnitTest(unittest.TestCase):
         self.assertEqual(str(c), '[V]')
         self.assertEqual(str(d), '[V]')
 
+    def test_str_1115(self):
+        # Test str() does not store representations with () in them
+        unit1 = myokit.units.mol / (1e3 * myokit.units.g)
+        unit2 = 1e-12 * myokit.units.mol / (1e3 * myokit.units.g)
+        unit3 = 1e-6 * unit2
+        self.assertEqual(str(unit1), '[mol/g (0.001)]')
+        # In issue 1115, this would be registered as a preferred
+        # representation, leading to the situation where str(unit2) would
+        # return [mol/g (0.001) (1e-12)]
+        self.assertEqual(str(unit2), '[mol/g (1e-15)]')
+        self.assertEqual(str(unit3), '[mol/g (1e-21)]')
+
     def test_repr(self):
         # Test :meth:`Unit.repr()`.
 

--- a/myokit/tests/test_unit.py
+++ b/myokit/tests/test_unit.py
@@ -296,23 +296,34 @@ class MyokitUnitTest(unittest.TestCase):
         self.assertEqual(x.exponents(), [0, 2, 1.5, 0, 0, 0, -1.23])
 
     def test_register_errors(self):
-        # Test errors for Unit.register (rest is already used a lot).
-        self.assertRaises(TypeError, myokit.Unit.register, 4, myokit.Unit())
+        # Test errors for Unit.register (rest of the method is already used
+        # throughout other tests).
+        self.assertRaises(myokit.InvalidNameError, myokit.Unit.register, 4,
+                          myokit.Unit())
         self.assertRaises(TypeError, myokit.Unit.register, 'hi', 4)
 
     def test_register_preferred_representation(self):
         # Test new representations can be registered
 
-        u = myokit.units.m**8
-        self.assertEqual(str(u), '[m^8]')
+        u = myokit.units.K / myokit.units.A
         try:
-            myokit.Unit.register_preferred_representation(
-                'abc', myokit.units.m**8)
-            self.assertEqual(str(u), '[abc]')
+            # Register valid unit
+            self.assertEqual(str(u), '[K/A]')  # also auto registers!
+            myokit.Unit.register_preferred_representation('mK/mA', u)
+            self.assertEqual(str(u), '[mK/mA]')
 
+            # Attempt registering something that isn't a unit
             self.assertRaisesRegex(
                 ValueError, 'must be a myokit.Unit',
                 myokit.Unit.register_preferred_representation, 'x', 123)
+
+            # Attempt registering a representation that doesn't match the unit
+            self.assertRaisesRegex(
+                ValueError, r'does not equal \[K/A] when parsed',
+                myokit.Unit.register_preferred_representation, 'm', u)
+            self.assertRaisesRegex(
+                ValueError, r'does not equal \[K/A \(2\)] when parsed',
+                myokit.Unit.register_preferred_representation, 'K/A', u * 2)
 
         finally:
             # Bypassing the public API, this is bad test design!
@@ -365,16 +376,14 @@ class MyokitUnitTest(unittest.TestCase):
         self.assertEqual(str(c), '[V]')
         self.assertEqual(str(d), '[V]')
 
-    def test_str_1115(self):
-        # Test str() does not store representations with () in them
+        # 1115: Test str() doesn't create representations with more than one
+        # multiplier.
         unit1 = myokit.units.mol / (1e3 * myokit.units.g)
         unit2 = 1e-12 * myokit.units.mol / (1e3 * myokit.units.g)
         unit3 = 1e-6 * unit2
         self.assertEqual(str(unit1), '[mol/g (0.001)]')
-        # In issue 1115, this would be registered as a preferred
-        # representation, leading to the situation where str(unit2) would
-        # return [mol/g (0.001) (1e-12)]
         self.assertEqual(str(unit2), '[mol/g (1e-15)]')
+        # Before fixing 1115, this returned [mol/g (0.001) (1e-12)]
         self.assertEqual(str(unit3), '[mol/g (1e-21)]')
 
     def test_repr(self):


### PR DESCRIPTION
Fixes #1115

Removes auto-register in `Unit.__str__`