### PR TITLE
Add pyproject.toml

### DIFF
--- a/.github/workflows/coverage-test.yml
+++ b/.github/workflows/coverage-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Myokit
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip
           python -m pip install .[optional]
           python -m pip install coverage codecov
           python .github/workflows/select-opencl-device.py

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Myokit
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip
           python -m pip install .[docs,optional,gui]
 
       - name: Show Myokit info

--- a/.github/workflows/style-test.yml
+++ b/.github/workflows/style-test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install flake8
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip
           python -m pip install flake8
 
       - name: Run style checking

--- a/.github/workflows/unit-tests-macos.yml
+++ b/.github/workflows/unit-tests-macos.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Myokit
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip
           python -m pip install .[optional]
           python .github/workflows/select-opencl-device.py
 

--- a/.github/workflows/unit-tests-numpy.yml
+++ b/.github/workflows/unit-tests-numpy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Myokit
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip
           python -m pip install .[optional]
           python .github/workflows/select-opencl-device.py
 

--- a/.github/workflows/unit-tests-sundials.yml
+++ b/.github/workflows/unit-tests-sundials.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Myokit
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip
           python -m pip install .[optional]
 
       - name: Show Myokit info

--- a/.github/workflows/unit-tests-ubuntu.yml
+++ b/.github/workflows/unit-tests-ubuntu.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Myokit
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip
           python -m pip install .[optional]
           python .github/workflows/select-opencl-device.py
 

--- a/.github/workflows/unit-tests-windows-miniconda.yml
+++ b/.github/workflows/unit-tests-windows-miniconda.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Myokit
         run: |
           C:\Miniconda\python.exe --version
-          C:\Miniconda\python.exe -m pip install --upgrade pip setuptools wheel
+          C:\Miniconda\python.exe -m pip install --upgrade pip
           C:\Miniconda\python.exe -m pip install .[optional]
           C:\Miniconda\python.exe .github/workflows/select-opencl-device.py
 

--- a/.github/workflows/unit-tests-windows.yml
+++ b/.github/workflows/unit-tests-windows.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Myokit
         run: |
           python --version
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip
           python -m pip install .[optional]
           python .github/workflows/select-opencl-device.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
 [build-system]
-requires = ["setuptools>=64"]
+requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
-

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ setup(
         'lxml',
         'matplotlib>=2.2',
         'numpy',
-        'setuptools',
         # PyQT or PySide?
         # (PySide is pip installable, Actions can get PyQt from apt)
     ],

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         'lxml',
         'matplotlib>=2.2',
         'numpy',
+        'setuptools',
         # PyQT or PySide?
         # (PySide is pip installable, Actions can get PyQt from apt)
     ],


### PR DESCRIPTION
Closes #1112 

**Changes**
* Adds a minimal `pyproject.toml` with build-time dependencies.
* Removes manual build-time installs of `wheel` and `setuptools` from github workflows