### PR TITLE
Fixed compilation error in FiberTissueSimulation and Simulation1d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This page lists the main changes made to Myokit in each release.
 - Removed
 - Fixed
   - [#1135](https://github.com/myokit/myokit/pull/1135) Fixed bug in PatchMasterFile where data types other than int 16 were not detected.
+  - [#1136](https://github.com/myokit/myokit/pull/1136) Fixed error in colormap attribution.
+  - [#1137](https://github.com/myokit/myokit/pull/1137) Fixed bug in FiberTissueSimulation and Simulation1d that was causing compilation errors.
 
 ## [1.37.4] - 2025-06-30
 - Added

--- a/myokit/_sim/cable.c
+++ b/myokit/_sim/cable.c
@@ -272,7 +272,7 @@ sim_clean()
     return 0;
 }
 static PyObject*
-py_sim_clean()
+py_sim_clean(PyObject *self, PyObject *args)
 {
     sim_clean();
     Py_RETURN_NONE;

--- a/myokit/_sim/fiber_tissue.c
+++ b/myokit/_sim/fiber_tissue.c
@@ -291,7 +291,7 @@ sim_clean()
     return 0;
 }
 static PyObject*
-py_sim_clean()
+py_sim_clean(PyObject *self, PyObject *args)
 {
     #ifdef MYOKIT_DEBUG_MESSAGES
     printf("Python py_sim_clean called.\n");


### PR DESCRIPTION
Both used wrong signature for a python callable C method